### PR TITLE
feat(github): require CI, enable auto-merge and squash-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Project Rules
+
+## github.tf
+
+- `import` ブロックは `terraform apply` 完了後も削除しない。リスト追加時に自動インポートされるよう常に残す。

--- a/github.tf
+++ b/github.tf
@@ -1,11 +1,38 @@
-resource "github_branch_protection" "main" {
-  for_each = toset([
+locals {
+  github_repos = toset([
     "go-exercise",
     "homepage4.0",
     "rb-exercise",
     "rs-exercise",
     "ts-exercise",
   ])
+}
+
+resource "github_repository" "repos" {
+  for_each = local.github_repos
+
+  name                        = each.key
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_squash_merge          = true
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "BLANK"
+  delete_branch_on_merge      = true
+
+  lifecycle {
+    ignore_changes = [description]
+  }
+}
+
+import {
+  for_each = local.github_repos
+  to       = github_repository.repos[each.key]
+  id       = each.key
+}
+
+resource "github_branch_protection" "main" {
+  for_each = local.github_repos
 
   repository_id = each.key
   pattern       = "main"
@@ -24,39 +51,4 @@ resource "github_branch_protection" "main" {
 
   allows_force_pushes = false
   allows_deletions    = false
-}
-
-resource "github_repository" "repos" {
-  for_each = toset([
-    "go-exercise",
-    "homepage4.0",
-    "rb-exercise",
-    "rs-exercise",
-    "ts-exercise",
-  ])
-
-  name                        = each.key
-  allow_auto_merge            = true
-  allow_merge_commit          = false
-  allow_rebase_merge          = false
-  allow_squash_merge          = true
-  squash_merge_commit_title   = "PR_TITLE"
-  squash_merge_commit_message = "BLANK"
-  delete_branch_on_merge      = true
-
-  lifecycle {
-    ignore_changes = [description]
-  }
-}
-
-import {
-  for_each = toset([
-    "go-exercise",
-    "homepage4.0",
-    "rb-exercise",
-    "rs-exercise",
-    "ts-exercise",
-  ])
-  to = github_repository.repos[each.key]
-  id = each.key
 }

--- a/github.tf
+++ b/github.tf
@@ -25,12 +25,6 @@ resource "github_repository" "repos" {
   }
 }
 
-import {
-  for_each = local.github_repos
-  to       = github_repository.repos[each.key]
-  id       = each.key
-}
-
 resource "github_branch_protection" "main" {
   for_each = local.github_repos
 

--- a/github.tf
+++ b/github.tf
@@ -35,8 +35,14 @@ resource "github_repository" "repos" {
     "ts-exercise",
   ])
 
-  name             = each.key
-  allow_auto_merge = true
+  name                        = each.key
+  allow_auto_merge            = true
+  allow_merge_commit          = false
+  allow_rebase_merge          = false
+  allow_squash_merge          = true
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "PR_BODY"
+  delete_branch_on_merge      = true
 }
 
 import {

--- a/github.tf
+++ b/github.tf
@@ -11,6 +11,11 @@ resource "github_branch_protection" "main" {
   pattern       = "main"
   enforce_admins = true
 
+  required_status_checks {
+    strict   = true
+    contexts = ["CI"]
+  }
+
   required_pull_request_reviews {
     dismiss_stale_reviews           = false
     require_code_owner_reviews      = false
@@ -19,4 +24,29 @@ resource "github_branch_protection" "main" {
 
   allows_force_pushes = false
   allows_deletions    = false
+}
+
+resource "github_repository" "repos" {
+  for_each = toset([
+    "go-exercise",
+    "homepage4.0",
+    "rb-exercise",
+    "rs-exercise",
+    "ts-exercise",
+  ])
+
+  name             = each.key
+  allow_auto_merge = true
+}
+
+import {
+  for_each = toset([
+    "go-exercise",
+    "homepage4.0",
+    "rb-exercise",
+    "rs-exercise",
+    "ts-exercise",
+  ])
+  to = github_repository.repos[each.key]
+  id = each.key
 }

--- a/github.tf
+++ b/github.tf
@@ -24,7 +24,7 @@ resource "github_repository" "repos" {
   has_wiki                    = true
 
   lifecycle {
-    ignore_changes = [description, has_downloads]
+    ignore_changes = [description]
   }
 }
 

--- a/github.tf
+++ b/github.tf
@@ -25,6 +25,12 @@ resource "github_repository" "repos" {
   }
 }
 
+import {
+  for_each = local.github_repos
+  to       = github_repository.repos[each.key]
+  id       = each.key
+}
+
 resource "github_branch_protection" "main" {
   for_each = local.github_repos
 

--- a/github.tf
+++ b/github.tf
@@ -43,6 +43,10 @@ resource "github_repository" "repos" {
   squash_merge_commit_title   = "PR_TITLE"
   squash_merge_commit_message = "PR_BODY"
   delete_branch_on_merge      = true
+
+  lifecycle {
+    ignore_changes = [description]
+  }
 }
 
 import {

--- a/github.tf
+++ b/github.tf
@@ -19,9 +19,12 @@ resource "github_repository" "repos" {
   squash_merge_commit_title   = "PR_TITLE"
   squash_merge_commit_message = "BLANK"
   delete_branch_on_merge      = true
+  has_issues                  = true
+  has_projects                = true
+  has_wiki                    = true
 
   lifecycle {
-    ignore_changes = [description]
+    ignore_changes = [description, has_downloads]
   }
 }
 

--- a/github.tf
+++ b/github.tf
@@ -41,7 +41,7 @@ resource "github_repository" "repos" {
   allow_rebase_merge          = false
   allow_squash_merge          = true
   squash_merge_commit_title   = "PR_TITLE"
-  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_message = "BLANK"
   delete_branch_on_merge      = true
 
   lifecycle {


### PR DESCRIPTION
## Summary
- CI ステータスチェックをブランチ保護の必須条件に追加
- 全リポジトリで auto-merge を有効化
- squash merge のみ許可（merge commit, rebase merge を無効化）
- `github_repository` リソースを追加し `import` ブロックで既存リポジトリを管理
- リポジトリリストを `local.github_repos` に共通化

## Test plan
- [x] `terraform apply` で正常に適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)