### PR TITLE
ci: add Terraform CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate

--- a/github.tf
+++ b/github.tf
@@ -37,8 +37,8 @@ import {
 resource "github_branch_protection" "main" {
   for_each = local.github_repos
 
-  repository_id = each.key
-  pattern       = "main"
+  repository_id  = each.key
+  pattern        = "main"
   enforce_admins = true
 
   required_status_checks {


### PR DESCRIPTION
## Summary
- Terraform の `fmt -check`, `init -backend=false`, `validate` を実行する CI ワークフローを追加
- public リポジトリのため、シークレット不要で fork PR でも動作
- ジョブ名 `CI` は branch protection の required status check と一致

## Test plan
- [x] PR 上で CI ワークフローが正常に実行されることを確認
- [x] `terraform fmt -check` / `validate` が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)