### PR TITLE
fix(github): ignore merge_commit_title/message drift on repos

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -26,7 +26,7 @@ resource "github_repository" "repos" {
   has_wiki                    = true
 
   lifecycle {
-    ignore_changes = [description]
+    ignore_changes = [description, merge_commit_title, merge_commit_message]
   }
 }
 


### PR DESCRIPTION
## Summary
- `github_repository.repos` の `lifecycle.ignore_changes` に `merge_commit_title` と `merge_commit_message` を追加し、`rs-exercise` で発生していた永続 drift を解消する

## Why
- `allow_merge_commit = false` の repo では GitHub API が `merge_commit_title` / `merge_commit_message` への PATCH を**サイレントに無視**する
- 一方 provider は config 未指定時の default（`MERGE_MESSAGE` / `PR_TITLE`）に揃えようとし続けるため、過去 UI 等で異なる値が設定された repo は永続 drift になる（実際 `rs-exercise` は `merge_commit_title=PR_TITLE`, `merge_commit_message=BLANK` で固定）
- merge commit 自体を無効化している以上これらのフィールドは機能的に無意味なので provider に管理させない

```
# 確認した実状態
rs-exercise: merge_commit_title=PR_TITLE,    merge_commit_message=BLANK    （drift）
go-exercise: merge_commit_title=MERGE_MESSAGE, merge_commit_message=PR_TITLE （provider default）
```

## Test plan
- [x] `terraform plan` で `github_repository.repos["rs-exercise"]` の `~ update in-place` が消えていることを確認
- [x] 他リポジトリで意図しない plan が発生しないことを確認