### PR TITLE
feat(github): restrict ruleset merge method to squash only

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -56,6 +56,7 @@ resource "github_repository_ruleset" "main" {
     non_fast_forward = false
 
     pull_request {
+      allowed_merge_methods           = ["squash"]
       dismiss_stale_reviews_on_push   = false
       require_code_owner_review       = false
       required_approving_review_count = 0


### PR DESCRIPTION
## Summary
- ruleset の `pull_request` ルールに `allowed_merge_methods = ["squash"]` を追加し、squash 以外のマージを ruleset レベルでも拒否する

## Test plan
- [x] `terraform plan` で対象リポジトリの ruleset に `allowed_merge_methods` 追加のみが差分として現れることを確認
- [x] `terraform apply` 後、GitHub UI の ruleset 設定でマージ方式が squash のみに制限されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)