### PR TITLE
refactor(github): remove required status checks from ruleset

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -61,13 +61,5 @@ resource "github_repository_ruleset" "main" {
       require_code_owner_review       = false
       required_approving_review_count = 0
     }
-
-    required_status_checks {
-      strict_required_status_checks_policy = true
-
-      required_check {
-        context = "CI"
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary

- \`github_repository_ruleset.main\` から \`required_status_checks\` ブロックを削除し、\"CI\" ステータスチェックの必須化を解除

## Test plan
- [x] \`terraform plan\` で対象 ruleset の \`required_status_checks\` が削除されること、他リソースに影響がないことを確認
- [x] マージ後、GitHub 上で ruleset の required status checks が外れていることを確認
