### PR TITLE
feat(cloudflare): read credentials from Secrets Manager via ephemeral resource

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -3,7 +3,9 @@ locals {
 }
 
 data "cloudflare_zone" "main" {
-  zone_id = var.cloudflare_zone_id
+  filter = {
+    name = local.domain
+  }
 }
 
 resource "cloudflare_dns_record" "mx" {

--- a/main.tf
+++ b/main.tf
@@ -21,12 +21,24 @@ terraform {
   }
 }
 
+data "aws_secretsmanager_secret" "tf_infra" {
+  name = "tf-infra"
+}
+
+ephemeral "aws_secretsmanager_secret_version" "tf_infra" {
+  secret_id = data.aws_secretsmanager_secret.tf_infra.id
+}
+
+locals {
+  secrets = jsondecode(ephemeral.aws_secretsmanager_secret_version.tf_infra.secret_string)
+}
+
 provider "aws" {
   region = "ap-northeast-1"
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  api_token = local.secrets.cloudflare_api_token
 }
 
 provider "github" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,0 @@
-variable "cloudflare_zone_id" {
-  type = string
-}
-
-variable "cloudflare_api_token" {
-  type      = string
-  sensitive = true
-}


### PR DESCRIPTION
## Summary

- Cloudflare の認証情報（`cloudflare_api_token` / `cloudflare_zone_id` 変数）を廃止し、AWS Secrets Manager の `tf-infra` シークレットを `ephemeral "aws_secretsmanager_secret_version"` で読み取る方式に変更
- ephemeral な値は data source の引数に使えないため、Cloudflare zone は名前で lookup するように変更

## Changes

- `main.tf`: `aws_secretsmanager_secret` data source と ephemeral な secret version 読み取りを追加
- `cloudflare.tf`: zone を名前で lookup するよう変更
- `variables.tf`: `cloudflare_api_token` / `cloudflare_zone_id` 変数を削除

## Test plan

- [x] `terraform plan` が変数入力なしで成功すること
- [x] Cloudflare リソースに差分が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
